### PR TITLE
fix(tracker): key fixed-ID map on (sensor_id, rtl433_id)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+tpms.db*

--- a/crates/tracker/src/db.rs
+++ b/crates/tracker/src/db.rs
@@ -122,6 +122,18 @@ impl Database {
         Ok(())
     }
 
+    /// Update the `rtl433_id` column for an existing vehicle row.
+    /// Used when a legacy row (migrated with `rtl433_id=0`) is adopted by a
+    /// packet carrying the real decoder ID, so the stored key is corrected
+    /// in place rather than creating a duplicate vehicle.
+    pub fn update_rtl433_id(&self, vehicle_id: Uuid, rtl433_id: u16) -> Result<()> {
+        self.conn.execute(
+            "UPDATE vehicles SET rtl433_id = ?1 WHERE vehicle_id = ?2",
+            params![rtl433_id as i64, vehicle_id.to_string()],
+        )?;
+        Ok(())
+    }
+
     /// Look up a vehicle by its fixed sensor_id.
     pub fn find_vehicle_by_sensor_id(&self, sensor_id: u32) -> Result<Option<VehicleTrack>> {
         let mut stmt = self.conn.prepare(

--- a/crates/tracker/src/db.rs
+++ b/crates/tracker/src/db.rs
@@ -188,7 +188,9 @@ fn row_to_vehicle(row: &rusqlite::Row<'_>) -> rusqlite::Result<VehicleTrack> {
         last_seen: parse_dt(&last_seen_s),
         sighting_count: sighting_count as u32,
         protocol,
-        rtl433_id: rtl433_id as u16,
+        rtl433_id: u16::try_from(rtl433_id).map_err(|_| {
+            rusqlite::Error::IntegralValueOutOfRange(8, rtl433_id)
+        })?,
         fixed_sensor_id: sensor_id.map(|id| id as u32),
         pressure_signature: serde_json::from_str(&pressure_sig_s).unwrap_or([0.0; 4]),
         make_model_hint: make_model,

--- a/crates/tracker/src/db.rs
+++ b/crates/tracker/src/db.rs
@@ -83,7 +83,9 @@ impl Database {
             ON CONFLICT(vehicle_id) DO UPDATE SET
                 last_seen      = excluded.last_seen,
                 sighting_count = excluded.sighting_count,
-                pressure_sig   = excluded.pressure_sig
+                pressure_sig   = excluded.pressure_sig,
+                rtl433_id      = CASE WHEN vehicles.rtl433_id = 0 THEN excluded.rtl433_id ELSE vehicles.rtl433_id END,
+                protocol       = CASE WHEN vehicles.rtl433_id = 0 THEN excluded.protocol   ELSE vehicles.protocol   END
             "#,
             params![
                 v.vehicle_id.to_string(),

--- a/crates/tracker/src/db.rs
+++ b/crates/tracker/src/db.rs
@@ -27,6 +27,7 @@ impl Database {
                 last_seen      TEXT NOT NULL,
                 sighting_count INTEGER NOT NULL DEFAULT 0,
                 protocol       TEXT NOT NULL,
+                rtl433_id      INTEGER NOT NULL DEFAULT 0,
                 sensor_id      INTEGER,        -- NULL for rolling-ID protocols
                 make_model     TEXT,
                 pressure_sig   TEXT NOT NULL DEFAULT '[0,0,0,0]'
@@ -50,6 +51,22 @@ impl Database {
             CREATE INDEX IF NOT EXISTS idx_sightings_ts      ON sightings(ts);
             "#,
         )?;
+
+        // Migration: add rtl433_id column for databases created before the
+        // cross-protocol-absorption fix. SQLite has no `ADD COLUMN IF NOT
+        // EXISTS`, so check pragma_table_info first.
+        let has_rtl433_id: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('vehicles') WHERE name='rtl433_id'",
+            [],
+            |row| row.get(0),
+        )?;
+        if has_rtl433_id == 0 {
+            self.conn.execute(
+                "ALTER TABLE vehicles ADD COLUMN rtl433_id INTEGER NOT NULL DEFAULT 0",
+                [],
+            )?;
+        }
+
         Ok(())
     }
 
@@ -61,8 +78,8 @@ impl Database {
         self.conn.execute(
             r#"
             INSERT INTO vehicles
-                (vehicle_id, first_seen, last_seen, sighting_count, protocol, sensor_id, make_model, pressure_sig)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                (vehicle_id, first_seen, last_seen, sighting_count, protocol, rtl433_id, sensor_id, make_model, pressure_sig)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
             ON CONFLICT(vehicle_id) DO UPDATE SET
                 last_seen      = excluded.last_seen,
                 sighting_count = excluded.sighting_count,
@@ -74,6 +91,7 @@ impl Database {
                 v.last_seen.to_rfc3339(),
                 v.sighting_count as i64,
                 v.protocol,
+                v.rtl433_id as i64,
                 v.fixed_sensor_id.map(|id| id as i64),
                 v.make_model_hint.as_deref(),
                 pressure_sig,
@@ -108,7 +126,7 @@ impl Database {
     pub fn find_vehicle_by_sensor_id(&self, sensor_id: u32) -> Result<Option<VehicleTrack>> {
         let mut stmt = self.conn.prepare(
             "SELECT vehicle_id, first_seen, last_seen, sighting_count, protocol,
-                    sensor_id, make_model, pressure_sig
+                    sensor_id, make_model, pressure_sig, rtl433_id
              FROM vehicles WHERE sensor_id = ?1 LIMIT 1",
         )?;
         let mut rows = stmt.query(params![sensor_id as i64])?;
@@ -123,7 +141,7 @@ impl Database {
     pub fn all_vehicles(&self) -> Result<Vec<VehicleTrack>> {
         let mut stmt = self.conn.prepare(
             "SELECT vehicle_id, first_seen, last_seen, sighting_count, protocol,
-                    sensor_id, make_model, pressure_sig
+                    sensor_id, make_model, pressure_sig, rtl433_id
              FROM vehicles ORDER BY last_seen DESC",
         )?;
         let vehicles = stmt
@@ -142,6 +160,7 @@ fn row_to_vehicle(row: &rusqlite::Row<'_>) -> rusqlite::Result<VehicleTrack> {
     let sensor_id: Option<i64> = row.get(5)?;
     let make_model: Option<String> = row.get(6)?;
     let pressure_sig_s: String = row.get(7)?;
+    let rtl433_id: i64 = row.get(8)?;
 
     let parse_dt = |s: &str| -> DateTime<Utc> {
         DateTime::parse_from_rfc3339(s)
@@ -155,6 +174,7 @@ fn row_to_vehicle(row: &rusqlite::Row<'_>) -> rusqlite::Result<VehicleTrack> {
         last_seen: parse_dt(&last_seen_s),
         sighting_count: sighting_count as u32,
         protocol,
+        rtl433_id: rtl433_id as u16,
         fixed_sensor_id: sensor_id.map(|id| id as u32),
         pressure_signature: serde_json::from_str(&pressure_sig_s).unwrap_or([0.0; 4]),
         make_model_hint: make_model,

--- a/crates/tracker/src/db.rs
+++ b/crates/tracker/src/db.rs
@@ -188,9 +188,8 @@ fn row_to_vehicle(row: &rusqlite::Row<'_>) -> rusqlite::Result<VehicleTrack> {
         last_seen: parse_dt(&last_seen_s),
         sighting_count: sighting_count as u32,
         protocol,
-        rtl433_id: u16::try_from(rtl433_id).map_err(|_| {
-            rusqlite::Error::IntegralValueOutOfRange(8, rtl433_id)
-        })?,
+        rtl433_id: u16::try_from(rtl433_id)
+            .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(8, rtl433_id))?,
         fixed_sensor_id: sensor_id.map(|id| id as u32),
         pressure_signature: serde_json::from_str(&pressure_sig_s).unwrap_or([0.0; 4]),
         make_model_hint: make_model,

--- a/crates/tracker/src/lib.rs
+++ b/crates/tracker/src/lib.rs
@@ -57,6 +57,11 @@ pub struct VehicleTrack {
     pub last_seen: DateTime<Utc>,
     pub sighting_count: u32,
     pub protocol: String,
+    /// Canonical rtl_433 decoder ID. Paired with `fixed_sensor_id` to form the
+    /// fixed-ID map key so that two sensors from different protocols that
+    /// happen to share a `sensor_id` value cannot be merged into the same
+    /// vehicle UUID.
+    pub rtl433_id: u16,
     /// Stable for pre-2018 fixed-ID sensors; `None` for rolling-ID protocols.
     pub fixed_sensor_id: Option<u32>,
     /// Exponential-moving-average pressure per wheel slot (kPa).

--- a/crates/tracker/src/resolver.rs
+++ b/crates/tracker/src/resolver.rs
@@ -470,8 +470,19 @@ mod tests {
     use super::*;
     use crate::db::Database;
 
-    fn make_packet(sensor_id: &str, protocol: &str, rtl433_id: u16, pressure_kpa: f32) -> TpmsPacket {
-        make_packet_at("2025-06-01 12:00:00.000", sensor_id, protocol, rtl433_id, pressure_kpa)
+    fn make_packet(
+        sensor_id: &str,
+        protocol: &str,
+        rtl433_id: u16,
+        pressure_kpa: f32,
+    ) -> TpmsPacket {
+        make_packet_at(
+            "2025-06-01 12:00:00.000",
+            sensor_id,
+            protocol,
+            rtl433_id,
+            pressure_kpa,
+        )
     }
 
     fn make_packet_at(
@@ -519,10 +530,7 @@ mod tests {
             );
         }
         assert!(
-            !resolver
-                .fixed_map
-                .keys()
-                .any(|(sid, _)| *sid == 0xFFFFFFFF),
+            !resolver.fixed_map.keys().any(|(sid, _)| *sid == 0xFFFFFFFF),
             "sentinel 0xFFFFFFFF must not appear in fixed_map"
         );
     }
@@ -545,10 +553,7 @@ mod tests {
             );
         }
         assert!(
-            !resolver
-                .fixed_map
-                .keys()
-                .any(|(sid, _)| *sid == 0x00000000),
+            !resolver.fixed_map.keys().any(|(sid, _)| *sid == 0x00000000),
             "sentinel 0x00000000 must not appear in fixed_map"
         );
     }
@@ -654,7 +659,11 @@ mod tests {
             eez_count, 1,
             "all six EezTire packets must collapse into a single vehicle"
         );
-        let v = resolver.vehicles.values().find(|v| v.protocol == "EezTire").unwrap();
+        let v = resolver
+            .vehicles
+            .values()
+            .find(|v| v.protocol == "EezTire")
+            .unwrap();
         assert_eq!(v.sighting_count, 6);
         assert!(v.fixed_sensor_id.is_none());
     }
@@ -665,14 +674,32 @@ mod tests {
         // the same pressure should resolve to a *different* vehicle UUID.
         let mut resolver = in_memory_resolver();
 
-        let p1 = make_packet_at("2025-06-01 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 51.1);
-        let p2 = make_packet_at("2025-06-01 12:00:10.000", "0xBFFFFFFF", "EezTire", 241, 51.1);
+        let p1 = make_packet_at(
+            "2025-06-01 12:00:00.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            51.1,
+        );
+        let p2 = make_packet_at(
+            "2025-06-01 12:00:10.000",
+            "0xBFFFFFFF",
+            "EezTire",
+            241,
+            51.1,
+        );
         let vid1 = resolver.process(&p1).unwrap().unwrap();
         let vid2 = resolver.process(&p2).unwrap().unwrap();
         assert_eq!(vid1, vid2, "packets inside the expiry window must merge");
 
         // > 5 minutes later, a new sighting should not merge with the earlier vehicle.
-        let p3 = make_packet_at("2025-06-01 12:05:11.000", "0x7FFFFF7F", "EezTire", 241, 51.1);
+        let p3 = make_packet_at(
+            "2025-06-01 12:05:11.000",
+            "0x7FFFFF7F",
+            "EezTire",
+            241,
+            51.1,
+        );
         let vid3 = resolver.process(&p3).unwrap().unwrap();
         assert_ne!(
             vid1, vid3,
@@ -687,10 +714,34 @@ mod tests {
         // vehicles.
         let mut resolver = in_memory_resolver();
 
-        let hi1 = make_packet_at("2025-06-01 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 51.1);
-        let lo1 = make_packet_at("2025-06-01 12:00:01.000", "0xBFFFFFFF", "EezTire", 241, 25.0);
-        let hi2 = make_packet_at("2025-06-01 12:00:02.000", "0x7FFEFFFE", "EezTire", 241, 51.2);
-        let lo2 = make_packet_at("2025-06-01 12:00:03.000", "0xEFFFF5FF", "EezTire", 241, 24.9);
+        let hi1 = make_packet_at(
+            "2025-06-01 12:00:00.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            51.1,
+        );
+        let lo1 = make_packet_at(
+            "2025-06-01 12:00:01.000",
+            "0xBFFFFFFF",
+            "EezTire",
+            241,
+            25.0,
+        );
+        let hi2 = make_packet_at(
+            "2025-06-01 12:00:02.000",
+            "0x7FFEFFFE",
+            "EezTire",
+            241,
+            51.2,
+        );
+        let lo2 = make_packet_at(
+            "2025-06-01 12:00:03.000",
+            "0xEFFFF5FF",
+            "EezTire",
+            241,
+            24.9,
+        );
 
         let vhi1 = resolver.process(&hi1).unwrap().unwrap();
         let vlo1 = resolver.process(&lo1).unwrap().unwrap();
@@ -698,8 +749,14 @@ mod tests {
         let vlo2 = resolver.process(&lo2).unwrap().unwrap();
 
         assert_ne!(vhi1, vlo1, "51 kPa and 25 kPa sensors must not merge");
-        assert_eq!(vhi1, vhi2, "both 51 kPa packets must resolve to same vehicle");
-        assert_eq!(vlo1, vlo2, "both 25 kPa packets must resolve to same vehicle");
+        assert_eq!(
+            vhi1, vhi2,
+            "both 51 kPa packets must resolve to same vehicle"
+        );
+        assert_eq!(
+            vlo1, vlo2,
+            "both 25 kPa packets must resolve to same vehicle"
+        );
 
         let eez_count = resolver
             .vehicles

--- a/crates/tracker/src/resolver.rs
+++ b/crates/tracker/src/resolver.rs
@@ -176,6 +176,63 @@ impl Resolver {
         // Look up or create the vehicle.
         let vehicle_id = if let Some(&vid) = self.fixed_map.get(&key) {
             vid
+        } else if rtl433_id != 0 {
+            // Legacy backward-compat bridge: a migrated row may have
+            // `rtl433_id=0` because the column did not exist at insert time.
+            // Check whether `(sensor_id, 0)` already maps to a vehicle whose
+            // protocol matches, and if so adopt it rather than creating a
+            // duplicate.
+            let legacy_key = (sensor_id, 0u16);
+            if let Some(&legacy_vid) = self.fixed_map.get(&legacy_key) {
+                let protocol_matches = self
+                    .vehicles
+                    .get(&legacy_vid)
+                    .map_or(false, |v| v.protocol == sighting.protocol);
+                if protocol_matches {
+                    // Migrate the in-memory key from (sensor_id, 0) to the
+                    // real (sensor_id, rtl433_id) and correct the stored value.
+                    self.fixed_map.remove(&legacy_key);
+                    self.fixed_map.insert(key, legacy_vid);
+                    if let Some(v) = self.vehicles.get_mut(&legacy_vid) {
+                        v.rtl433_id = rtl433_id;
+                    }
+                    self.db.update_rtl433_id(legacy_vid, rtl433_id)?;
+                    legacy_vid
+                } else {
+                    // Different protocol — create a new vehicle as normal.
+                    let vid = Uuid::new_v4();
+                    let vehicle = VehicleTrack {
+                        vehicle_id: vid,
+                        first_seen: sighting.ts,
+                        last_seen: sighting.ts,
+                        sighting_count: 0,
+                        protocol: sighting.protocol.clone(),
+                        rtl433_id,
+                        fixed_sensor_id: Some(sensor_id),
+                        pressure_signature: [sighting.pressure_kpa, 0.0, 0.0, 0.0],
+                        make_model_hint: make_model_hint(rtl433_id).map(str::to_owned),
+                    };
+                    self.fixed_map.insert(key, vid);
+                    self.vehicles.insert(vid, vehicle);
+                    vid
+                }
+            } else {
+                let vid = Uuid::new_v4();
+                let vehicle = VehicleTrack {
+                    vehicle_id: vid,
+                    first_seen: sighting.ts,
+                    last_seen: sighting.ts,
+                    sighting_count: 0,
+                    protocol: sighting.protocol.clone(),
+                    rtl433_id,
+                    fixed_sensor_id: Some(sensor_id),
+                    pressure_signature: [sighting.pressure_kpa, 0.0, 0.0, 0.0],
+                    make_model_hint: make_model_hint(rtl433_id).map(str::to_owned),
+                };
+                self.fixed_map.insert(key, vid);
+                self.vehicles.insert(vid, vehicle);
+                vid
+            }
         } else {
             let vid = Uuid::new_v4();
             let vehicle = VehicleTrack {

--- a/crates/tracker/src/resolver.rs
+++ b/crates/tracker/src/resolver.rs
@@ -78,8 +78,14 @@ struct BurstAccumulator {
 // ---------------------------------------------------------------------------
 
 pub struct Resolver {
-    /// Stable sensor_id → vehicle_id for fixed-ID protocols.
-    fixed_map: HashMap<u32, Uuid>,
+    /// `(sensor_id, rtl433_id) → vehicle_id` for fixed-ID protocols.
+    ///
+    /// The decoder ID is part of the key so that two sensors from different
+    /// protocols that happen to share a `sensor_id` value cannot be absorbed
+    /// into the same vehicle UUID. See the issue "Fixed-ID lookup does not
+    /// verify protocol, allows near-sentinel cross-protocol absorption" for
+    /// background.
+    fixed_map: HashMap<(u32, u16), Uuid>,
     /// All tracked vehicles keyed by vehicle_id.
     vehicles: HashMap<Uuid, VehicleTrack>,
     /// Accumulator for an in-progress rolling-ID burst.
@@ -103,7 +109,8 @@ impl Resolver {
     fn load_from_db(&mut self) -> Result<()> {
         for vehicle in self.db.all_vehicles()? {
             if let Some(sid) = vehicle.fixed_sensor_id {
-                self.fixed_map.insert(sid, vehicle.vehicle_id);
+                self.fixed_map
+                    .insert((sid, vehicle.rtl433_id), vehicle.vehicle_id);
             }
             self.vehicles.insert(vehicle.vehicle_id, vehicle);
         }
@@ -161,9 +168,13 @@ impl Resolver {
 
     fn process_fixed(&mut self, sighting: Sighting, rtl433_id: u16) -> Result<Option<Uuid>> {
         let sensor_id = sighting.sensor_id;
+        // Key the fixed-ID map on `(sensor_id, rtl433_id)` so that two
+        // sensors from different decoders sharing a `sensor_id` value produce
+        // distinct vehicle UUIDs instead of merging.
+        let key = (sensor_id, rtl433_id);
 
         // Look up or create the vehicle.
-        let vehicle_id = if let Some(&vid) = self.fixed_map.get(&sensor_id) {
+        let vehicle_id = if let Some(&vid) = self.fixed_map.get(&key) {
             vid
         } else {
             let vid = Uuid::new_v4();
@@ -173,11 +184,12 @@ impl Resolver {
                 last_seen: sighting.ts,
                 sighting_count: 0,
                 protocol: sighting.protocol.clone(),
+                rtl433_id,
                 fixed_sensor_id: Some(sensor_id),
                 pressure_signature: [sighting.pressure_kpa, 0.0, 0.0, 0.0],
                 make_model_hint: make_model_hint(rtl433_id).map(str::to_owned),
             };
-            self.fixed_map.insert(sensor_id, vid);
+            self.fixed_map.insert(key, vid);
             self.vehicles.insert(vid, vehicle);
             vid
         };
@@ -232,6 +244,7 @@ impl Resolver {
                 last_seen: now,
                 sighting_count: 0,
                 protocol: protocol.clone(),
+                rtl433_id,
                 fixed_sensor_id: None,
                 pressure_signature: [pressure, 0.0, 0.0, 0.0],
                 make_model_hint: make_model_hint(rtl433_id).map(str::to_owned),
@@ -328,6 +341,7 @@ impl Resolver {
                 last_seen: now,
                 sighting_count: 0,
                 protocol: burst.protocol.clone(),
+                rtl433_id: burst.rtl433_id,
                 fixed_sensor_id: None,
                 pressure_signature: sig,
                 make_model_hint: make_model_hint(burst.rtl433_id).map(str::to_owned),
@@ -448,7 +462,10 @@ mod tests {
             );
         }
         assert!(
-            !resolver.fixed_map.contains_key(&0xFFFFFFFF),
+            !resolver
+                .fixed_map
+                .keys()
+                .any(|(sid, _)| *sid == 0xFFFFFFFF),
             "sentinel 0xFFFFFFFF must not appear in fixed_map"
         );
     }
@@ -471,7 +488,10 @@ mod tests {
             );
         }
         assert!(
-            !resolver.fixed_map.contains_key(&0x00000000),
+            !resolver
+                .fixed_map
+                .keys()
+                .any(|(sid, _)| *sid == 0x00000000),
             "sentinel 0x00000000 must not appear in fixed_map"
         );
     }
@@ -528,10 +548,10 @@ mod tests {
 
         // All 5 sightings should map to the same vehicle via the fixed-ID path.
         assert!(
-            resolver.fixed_map.contains_key(&0xFEFFFFFD),
+            resolver.fixed_map.contains_key(&(0xFEFFFFFD, 298)),
             "valid ID 0xFEFFFFFD must be in the fixed_map"
         );
-        let vid = resolver.fixed_map[&0xFEFFFFFD];
+        let vid = resolver.fixed_map[&(0xFEFFFFFD, 298)];
         let vehicle = &resolver.vehicles[&vid];
         assert_eq!(vehicle.sighting_count, 5);
         assert_eq!(vehicle.fixed_sensor_id, Some(0xFEFFFFFD));
@@ -630,6 +650,44 @@ mod tests {
             .filter(|v| v.protocol == "EezTire")
             .count();
         assert_eq!(eez_count, 2);
+    }
+
+    #[test]
+    fn fixed_id_map_keyed_on_protocol_does_not_merge_across_decoders() {
+        // Two sightings with identical sensor_id but different rtl433_id
+        // values must resolve to distinct vehicle UUIDs via the fixed-ID
+        // path. This is the defence-in-depth guard against cross-protocol
+        // absorption — if two decoders happen to emit the same sensor_id,
+        // keying the map on sensor_id alone would merge them. Keying on
+        // (sensor_id, rtl433_id) must keep them separate.
+        let mut resolver = in_memory_resolver();
+
+        // Pick a sensor_id that passes is_valid_sensor_id (plenty of bits
+        // cleared, not near the all-ones sentinel).
+        let shared_id = "0x1A2B3C4D";
+
+        let p_trw = make_packet(shared_id, "TRW-OOK", 298, 63.8);
+        let p_hyu = make_packet(shared_id, "Hyundai-Elantra", 140, 255.0);
+
+        let vid_trw = resolver.process(&p_trw).unwrap().expect("vid");
+        let vid_hyu = resolver.process(&p_hyu).unwrap().expect("vid");
+
+        assert_ne!(
+            vid_trw, vid_hyu,
+            "same sensor_id from two different decoders must produce distinct vehicle UUIDs"
+        );
+
+        // Both entries must be present in the fixed_map under their
+        // (sensor_id, rtl433_id) keys.
+        assert!(resolver.fixed_map.contains_key(&(0x1A2B3C4D, 298)));
+        assert!(resolver.fixed_map.contains_key(&(0x1A2B3C4D, 140)));
+        assert_eq!(resolver.vehicles.len(), 2);
+
+        // A subsequent TRW packet with the shared ID must rejoin the TRW
+        // vehicle, not flip to the Hyundai one.
+        let p_trw2 = make_packet(shared_id, "TRW-OOK", 298, 63.9);
+        let vid_trw2 = resolver.process(&p_trw2).unwrap().expect("vid");
+        assert_eq!(vid_trw, vid_trw2);
     }
 
     #[test]


### PR DESCRIPTION
Two sensors from different decoders that happen to share a sensor_id
value would merge into the same vehicle UUID via the fixed-ID path,
because the map was keyed on sensor_id alone. This is the structural
root of the b95a5e25 / 6abbddf3 cross-protocol absorption regressions;
the popcount sentinel check narrows the surface area but does not close
the gap for non-sentinel IDs.

Key the fixed_map on (sensor_id, rtl433_id) so that identical sensor_id
values from different decoders always produce distinct vehicles. The
canonical rtl_433 decoder ID is used instead of the protocol name
string because it is the stable identifier throughout the codebase.

VehicleTrack gains an rtl433_id field so that the key can be
reconstructed when the resolver reloads vehicles from the database;
the vehicles table gets a new rtl433_id column with a runtime migration
(ALTER TABLE guarded by pragma_table_info) for pre-existing databases.

Note: the tracker issue suggested (u32, u8), but rtl433_id is u16
throughout the existing codebase, so the key is (u32, u16) to stay
consistent.