### PR TITLE
feat(jitter): record raw TX intervals upstream of correlator (#42)

### DIFF
--- a/crates/tracker/src/lib.rs
+++ b/crates/tracker/src/lib.rs
@@ -3,6 +3,7 @@ pub mod classification;
 pub mod db;
 pub mod jaccard;
 pub mod jitter;
+pub mod raw_interval;
 pub mod replay;
 pub mod resolver;
 pub mod server;

--- a/crates/tracker/src/raw_interval.rs
+++ b/crates/tracker/src/raw_interval.rs
@@ -1,0 +1,354 @@
+//! Raw inter-packet interval tracking, upstream of the fingerprint correlator.
+//!
+//! The fingerprint correlator only matches a fraction of received packets
+//! (rolling/bit-flipping IDs miss most matches), so the gap between two
+//! consecutive correlator matches is much larger than the sensor's true TX
+//! cadence.  Recording jitter from inter-match gaps measures correlator
+//! behaviour, not the crystal oscillator.
+//!
+//! [`RawIntervalTracker`] records the gap between consecutive packets keyed
+//! by `(sensor_id, rtl433_id)` *before* fingerprint resolution.  The interval
+//! corresponds to the sensor's TX cadence (typically 15–60 s) and reflects
+//! the true oscillator jitter.
+//!
+//! Because the fingerprint that owns these intervals is unknown until the
+//! correlator runs, [`RawIntervalBuffer`] queues them per
+//! `(sensor_id, rtl433_id)` until the resolver flushes them after
+//! fingerprint assignment.
+
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Minimum plausible inter-packet gap (ms).  Anything below this is treated
+/// as a burst duplicate of the same packet (e.g. multipath echo).
+pub const RAW_INTERVAL_MIN_MS: i64 = 5_000;
+
+/// Maximum plausible inter-packet gap (ms).  Anything above this is treated
+/// as a cross-session gap (vehicle absent, then returns).  Set to ~3× the
+/// longest known TPMS TX interval (EezTire ~90s when parked).
+pub const RAW_INTERVAL_MAX_MS: i64 = 300_000;
+
+/// TTL (seconds) for buffered intervals awaiting fingerprint association.
+/// Buffered entries older than this are dropped — they belong to transient
+/// drive-bys that never resolved to a fingerprint.
+pub const RAW_INTERVAL_BUFFER_TTL_SECS: i64 = 600;
+
+// ---------------------------------------------------------------------------
+// RawIntervalTracker
+// ---------------------------------------------------------------------------
+
+/// Tracks the last-seen timestamp per `(sensor_id, rtl433_id)` pair so that
+/// inter-packet intervals can be computed before fingerprint resolution.
+///
+/// This is the input side of the deferred-association pipeline.  Successful
+/// observations (within the plausibility gate) are pushed into a
+/// [`RawIntervalBuffer`] that is later flushed to `interval_samples` once
+/// the correlator has resolved a fingerprint for the sensor.
+#[derive(Debug, Default)]
+pub struct RawIntervalTracker {
+    last_seen: HashMap<(u32, u16), DateTime<Utc>>,
+}
+
+impl RawIntervalTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a packet observation.  Returns the interval (ms) since the
+    /// previous packet from the same `(sensor_id, rtl433_id)` pair, if it
+    /// falls inside `[RAW_INTERVAL_MIN_MS, RAW_INTERVAL_MAX_MS]`.
+    ///
+    /// Returns `None` for the first observation of a sensor, for burst
+    /// duplicates, and for cross-session gaps.
+    pub fn observe(
+        &mut self,
+        sensor_id: u32,
+        rtl433_id: u16,
+        now: DateTime<Utc>,
+    ) -> Option<i64> {
+        let key = (sensor_id, rtl433_id);
+        let prev = self.last_seen.insert(key, now);
+        prev.and_then(|t| {
+            let gap = (now - t).num_milliseconds();
+            if (RAW_INTERVAL_MIN_MS..=RAW_INTERVAL_MAX_MS).contains(&gap) {
+                Some(gap)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Drop entries whose last-seen timestamp is older than `max_age_secs`.
+    /// Call periodically to release memory for sensors that have departed.
+    pub fn evict_stale(&mut self, now: DateTime<Utc>, max_age_secs: i64) {
+        self.last_seen
+            .retain(|_, t| (now - *t).num_seconds() < max_age_secs);
+    }
+
+    /// Number of tracked sensor keys.  Exposed for tests and diagnostics.
+    pub fn len(&self) -> usize {
+        self.last_seen.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.last_seen.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RawIntervalBuffer
+// ---------------------------------------------------------------------------
+
+/// One buffered observation: `(interval_ms, observed_at)`.
+type BufferedInterval = (i64, DateTime<Utc>);
+
+/// Short-lived buffer of raw intervals awaiting fingerprint association.
+///
+/// Entries are keyed on `(sensor_id, rtl433_id)`.  The resolver pushes
+/// intervals here as packets arrive and drains them with [`Self::drain`]
+/// once the correlator has resolved a fingerprint for that sensor.  Stale
+/// entries (those whose owning sensor never resolves) are dropped by
+/// [`Self::evict_stale`].
+#[derive(Debug, Default)]
+pub struct RawIntervalBuffer {
+    inner: HashMap<(u32, u16), Vec<BufferedInterval>>,
+}
+
+impl RawIntervalBuffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an interval observation for the given sensor.
+    pub fn push(
+        &mut self,
+        sensor_id: u32,
+        rtl433_id: u16,
+        interval_ms: i64,
+        ts: DateTime<Utc>,
+    ) {
+        self.inner
+            .entry((sensor_id, rtl433_id))
+            .or_default()
+            .push((interval_ms, ts));
+    }
+
+    /// Remove and return all buffered intervals for the given sensor key.
+    pub fn drain(&mut self, sensor_id: u32, rtl433_id: u16) -> Vec<BufferedInterval> {
+        self.inner
+            .remove(&(sensor_id, rtl433_id))
+            .unwrap_or_default()
+    }
+
+    /// Drop intervals older than `ttl_secs` and any sensor key that has no
+    /// remaining intervals afterwards.
+    pub fn evict_stale(&mut self, now: DateTime<Utc>, ttl_secs: i64) {
+        self.inner.retain(|_, intervals| {
+            intervals.retain(|(_, ts)| (now - *ts).num_seconds() < ttl_secs);
+            !intervals.is_empty()
+        });
+    }
+
+    /// Total number of buffered interval observations across all sensor keys.
+    pub fn len(&self) -> usize {
+        self.inner.values().map(|v| v.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.values().all(|v| v.is_empty())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone};
+
+    fn t0() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // RawIntervalTracker::observe
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn first_observation_returns_none() {
+        let mut tracker = RawIntervalTracker::new();
+        assert_eq!(tracker.observe(0x1234, 89, t0()), None);
+    }
+
+    #[test]
+    fn normal_gap_returns_interval() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        let gap = tracker.observe(0x1234, 89, t0() + Duration::milliseconds(22_000));
+        assert_eq!(gap, Some(22_000));
+    }
+
+    #[test]
+    fn burst_duplicate_below_min_rejected() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        // 200 ms gap is well below RAW_INTERVAL_MIN_MS (5_000).
+        let gap = tracker.observe(0x1234, 89, t0() + Duration::milliseconds(200));
+        assert_eq!(
+            gap, None,
+            "burst duplicate gaps below RAW_INTERVAL_MIN_MS must be rejected"
+        );
+    }
+
+    #[test]
+    fn cross_session_gap_above_max_rejected() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        // 10 minutes is well above RAW_INTERVAL_MAX_MS (300_000 ms).
+        let gap = tracker.observe(0x1234, 89, t0() + Duration::minutes(10));
+        assert_eq!(
+            gap, None,
+            "cross-session gaps above RAW_INTERVAL_MAX_MS must be rejected"
+        );
+    }
+
+    #[test]
+    fn min_boundary_accepted() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        let gap = tracker.observe(
+            0x1234,
+            89,
+            t0() + Duration::milliseconds(RAW_INTERVAL_MIN_MS),
+        );
+        assert_eq!(gap, Some(RAW_INTERVAL_MIN_MS));
+    }
+
+    #[test]
+    fn max_boundary_accepted() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        let gap = tracker.observe(
+            0x1234,
+            89,
+            t0() + Duration::milliseconds(RAW_INTERVAL_MAX_MS),
+        );
+        assert_eq!(gap, Some(RAW_INTERVAL_MAX_MS));
+    }
+
+    #[test]
+    fn different_protocols_kept_separate() {
+        // Same sensor_id under two different rtl433 IDs must not produce an
+        // interval — they are independent sensors as far as the tracker is
+        // concerned.
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        let gap = tracker.observe(0x1234, 95, t0() + Duration::milliseconds(22_000));
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn last_seen_advances_each_observation() {
+        // Three packets at 22 s spacing produce two intervals, both 22 s.
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1234, 89, t0());
+        let g1 = tracker.observe(0x1234, 89, t0() + Duration::milliseconds(22_000));
+        let g2 = tracker.observe(0x1234, 89, t0() + Duration::milliseconds(44_000));
+        assert_eq!(g1, Some(22_000));
+        assert_eq!(g2, Some(22_000));
+    }
+
+    // -----------------------------------------------------------------------
+    // RawIntervalTracker::evict_stale
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn evict_stale_removes_old_entries() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1111, 89, t0());
+        tracker.observe(0x2222, 89, t0() + Duration::seconds(150));
+        // Now is t0 + 200 s.  0x1111 is 200 s old (stale at 60 s max age);
+        // 0x2222 is 50 s old (still fresh).
+        tracker.evict_stale(t0() + Duration::seconds(200), 60);
+        assert_eq!(
+            tracker.len(),
+            1,
+            "only the recent entry should survive eviction"
+        );
+    }
+
+    #[test]
+    fn evict_stale_keeps_recent_entries() {
+        let mut tracker = RawIntervalTracker::new();
+        tracker.observe(0x1111, 89, t0());
+        tracker.evict_stale(t0() + Duration::seconds(30), 60);
+        assert_eq!(tracker.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // RawIntervalBuffer
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn buffer_drain_returns_buffered_intervals() {
+        let mut buf = RawIntervalBuffer::new();
+        buf.push(0x1234, 89, 22_000, t0());
+        buf.push(0x1234, 89, 22_050, t0() + Duration::milliseconds(22_050));
+
+        let drained = buf.drain(0x1234, 89);
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, 22_000);
+        assert_eq!(drained[1].0, 22_050);
+
+        // A second drain returns nothing — the buffer was emptied.
+        assert!(buf.drain(0x1234, 89).is_empty());
+    }
+
+    #[test]
+    fn buffer_drain_isolates_keys() {
+        let mut buf = RawIntervalBuffer::new();
+        buf.push(0x1111, 89, 22_000, t0());
+        buf.push(0x2222, 89, 30_000, t0());
+
+        let drained = buf.drain(0x1111, 89);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].0, 22_000);
+
+        // The other key is untouched.
+        let other = buf.drain(0x2222, 89);
+        assert_eq!(other.len(), 1);
+        assert_eq!(other[0].0, 30_000);
+    }
+
+    #[test]
+    fn buffer_evict_stale_removes_old_intervals() {
+        let mut buf = RawIntervalBuffer::new();
+        buf.push(0x1234, 89, 22_000, t0());
+        buf.push(0x1234, 89, 22_000, t0() + Duration::seconds(900));
+
+        // Evict anything older than 600 s relative to t0 + 900 s.
+        buf.evict_stale(t0() + Duration::seconds(900), 600);
+
+        let drained = buf.drain(0x1234, 89);
+        assert_eq!(
+            drained.len(),
+            1,
+            "only the recent interval should survive eviction"
+        );
+    }
+
+    #[test]
+    fn buffer_evict_stale_drops_empty_keys() {
+        let mut buf = RawIntervalBuffer::new();
+        buf.push(0x1234, 89, 22_000, t0());
+        // Force every interval out by evicting with a very large now.
+        buf.evict_stale(t0() + Duration::seconds(10_000), 600);
+        assert!(buf.is_empty());
+    }
+}

--- a/crates/tracker/src/resolver.rs
+++ b/crates/tracker/src/resolver.rs
@@ -13,6 +13,9 @@ use crate::jaccard::{
     infer_wheel_positions,
 };
 use crate::jitter;
+use crate::raw_interval::{
+    RAW_INTERVAL_BUFFER_TTL_SECS, RAW_INTERVAL_MAX_MS, RawIntervalBuffer, RawIntervalTracker,
+};
 use crate::{
     CROSS_RECEIVER_WINDOW_MS, FINGERPRINT_MAX_GAP_DAYS, MAX_PLAUSIBLE_PRESSURE_KPA,
     MIN_PLAUSIBLE_PRESSURE_KPA, Sighting, TX_INTERVAL_MAX_MS, TX_INTERVAL_MIN_SAMPLES,
@@ -146,6 +149,18 @@ pub struct Resolver {
     /// Car-IDs that have already been merged (absorbed) into another car.
     /// Prevents duplicate merge log events across grouping passes.
     merged_car_ids: HashSet<(Uuid, Uuid)>,
+    /// Tracks last-seen timestamp per `(sensor_id, rtl433_id)` to compute
+    /// raw inter-packet intervals upstream of the fingerprint correlator.
+    /// These intervals reflect the true TX cadence (and hence oscillator
+    /// jitter) rather than the inter-correlator-match latency.
+    raw_interval_tracker: RawIntervalTracker,
+    /// Buffers raw intervals per sensor key until the correlator resolves a
+    /// fingerprint for the sensor.  Drained into `interval_samples` after
+    /// resolution; stale entries are dropped after `RAW_INTERVAL_BUFFER_TTL_SECS`.
+    raw_interval_buffer: RawIntervalBuffer,
+    /// Last time stale entries were evicted from the raw-interval tracker
+    /// and buffer.  Used to throttle eviction to roughly once per minute.
+    last_raw_interval_evict: Option<DateTime<Utc>>,
 }
 
 impl Resolver {
@@ -168,6 +183,9 @@ impl Resolver {
             vehicle_to_car: HashMap::new(),
             vehicle_to_fingerprint: HashMap::new(),
             merged_car_ids: HashSet::new(),
+            raw_interval_tracker: RawIntervalTracker::new(),
+            raw_interval_buffer: RawIntervalBuffer::new(),
+            last_raw_interval_evict: None,
         };
         r.load_from_db()?;
         Ok(r)
@@ -228,6 +246,20 @@ impl Resolver {
             return Ok(None);
         };
 
+        // Record raw inter-packet interval BEFORE the correlator runs.  The
+        // correlator only matches a fraction of received packets (rolling and
+        // bit-flip IDs miss most matches), so any interval taken downstream
+        // measures inter-match latency rather than the sensor's true TX
+        // cadence.  Successful observations are buffered per-sensor and
+        // flushed to interval_samples after fingerprint resolution.
+        if let Some(interval_ms) =
+            self.raw_interval_tracker
+                .observe(sensor_id, packet.rtl433_id, ts)
+        {
+            self.raw_interval_buffer
+                .push(sensor_id, packet.rtl433_id, interval_ms, ts);
+        }
+
         // Discard temperature sentinel values (≥ 200 °C means "not available").
         let temp_c = packet.temp_c.filter(|&t| t < 200.0);
 
@@ -257,14 +289,88 @@ impl Resolver {
             },
         };
 
-        if BIT_FLIP_ID_PROTOCOLS.contains(&packet.rtl433_id) {
+        let result = if BIT_FLIP_ID_PROTOCOLS.contains(&packet.rtl433_id) {
             self.process_fingerprint(sighting)
         } else if ROLLING_ID_PROTOCOLS.contains(&packet.rtl433_id) || !is_valid_sensor_id(sensor_id)
         {
             self.process_rolling(sighting)
         } else {
             self.process_fixed(sighting, packet.rtl433_id)
+        };
+
+        // After the correlator has resolved (or failed to resolve) a vehicle
+        // for this packet, flush any buffered raw intervals for the same
+        // (sensor_id, rtl433_id) into interval_samples.  This deferred-
+        // association strategy lets us record the upstream interval even
+        // though the fingerprint identity is only known post-correlation.
+        if let Ok(Some(vehicle_id)) = result.as_ref()
+            && let Some(fp_id) = self.vehicle_to_fingerprint.get(vehicle_id).cloned()
+        {
+            self.flush_raw_intervals_for_sensor(
+                sensor_id,
+                packet.rtl433_id,
+                *vehicle_id,
+                &fp_id,
+            );
         }
+
+        // Throttled eviction of stale tracker entries and unresolved buffer
+        // entries.  Runs at most once a minute to bound memory.
+        self.maybe_evict_raw_intervals(ts);
+
+        result
+    }
+
+    /// Flush all buffered raw intervals for a given sensor key into
+    /// `interval_samples` under the resolved `fingerprint_id`.
+    fn flush_raw_intervals_for_sensor(
+        &mut self,
+        sensor_id: u32,
+        rtl433_id: u16,
+        vehicle_id: Uuid,
+        fingerprint_id: &str,
+    ) {
+        let intervals = self.raw_interval_buffer.drain(sensor_id, rtl433_id);
+        if intervals.is_empty() {
+            return;
+        }
+        for (interval_ms, ts) in intervals {
+            if let Err(e) = self.db.insert_interval_sample(
+                fingerprint_id,
+                vehicle_id,
+                &ts.to_rfc3339(),
+                interval_ms,
+                None,
+            ) {
+                eprintln!("warn: raw interval sample insert failed: {e}");
+                continue;
+            }
+            if let Err(e) = self
+                .db
+                .enforce_interval_ring_buffer(fingerprint_id, jitter::MAX_INTERVAL_SAMPLES)
+            {
+                eprintln!("warn: ring buffer enforce failed: {e}");
+            }
+        }
+    }
+
+    /// Periodically prune the raw-interval tracker and buffer.  Runs at most
+    /// once per minute; older sensor entries (older than `RAW_INTERVAL_MAX_MS`)
+    /// are dropped from the tracker, and unresolved buffered intervals older
+    /// than `RAW_INTERVAL_BUFFER_TTL_SECS` are discarded.
+    fn maybe_evict_raw_intervals(&mut self, now: DateTime<Utc>) {
+        let due = match self.last_raw_interval_evict {
+            Some(prev) => (now - prev).num_seconds() >= 60,
+            None => true,
+        };
+        if !due {
+            return;
+        }
+        self.last_raw_interval_evict = Some(now);
+        self.raw_interval_tracker
+            .evict_stale(now, RAW_INTERVAL_MAX_MS / 1000);
+        self.raw_interval_buffer
+            .evict_stale(now, RAW_INTERVAL_BUFFER_TTL_SECS);
     }
 
     /// Flush any pending rolling-ID burst.  Call this when the input stream ends.
@@ -765,11 +871,11 @@ impl Resolver {
             vid
         };
 
-        // Capture the previous last_seen timestamp before the state update overwrites it.
-        // Used below to compute the inter-packet gap for jitter interval recording.
-        let prev_last_seen = self.vehicles.get(&vehicle_id).map(|v| v.last_seen);
-
         // Cross-receiver dedup check + update in-memory state.
+        // Note: jitter interval recording happens upstream in `process()` via
+        // `RawIntervalTracker` / `RawIntervalBuffer`, so we no longer derive
+        // intervals from `last_seen` here — those gaps measure inter-correlator-
+        // match latency, not the sensor's TX cadence.
         let is_dup = {
             let vehicle = self.vehicles.get(&vehicle_id).unwrap();
             Self::is_cross_receiver_duplicate(vehicle, &sighting)
@@ -829,30 +935,6 @@ impl Resolver {
                 &now.to_rfc3339(),
                 sighting.alarm,
             );
-        }
-
-        // Record interval sample for jitter analytics (non-duplicate sightings only).
-        if !is_dup {
-            if let Some(prev_ts) = prev_last_seen {
-                if let Some(interval) = jitter::extract_interval(prev_ts, now) {
-                    if let Some(fp_id) = self.vehicle_to_fingerprint.get(&vehicle_id) {
-                        if let Err(e) = self.db.insert_interval_sample(
-                            fp_id,
-                            vehicle_id,
-                            &now.to_rfc3339(),
-                            interval,
-                            None,
-                        ) {
-                            eprintln!("warn: interval sample insert failed: {e}");
-                        } else if let Err(e) = self
-                            .db
-                            .enforce_interval_ring_buffer(fp_id, jitter::MAX_INTERVAL_SAMPLES)
-                        {
-                            eprintln!("warn: ring buffer enforce failed: {e}");
-                        }
-                    }
-                }
-            }
         }
 
         // Incrementally update presence slot if car_id is assigned.
@@ -1111,14 +1193,13 @@ impl Resolver {
             vid
         };
 
-        // Capture the previous last_seen timestamp before the state update overwrites it.
-        let prev_last_seen = self.vehicles.get(&vehicle_id).map(|v| v.last_seen);
-
         // Update in-memory state.
         // Note: rolling-ID bursts do not carry per-sighting receiver_id
         // metadata (the burst accumulator merges multiple packets), so
         // cross-receiver dedup is not applied here.  The burst uses the
         // resolver's own receiver_id.
+        // Jitter interval recording happens upstream in `process()` via
+        // `RawIntervalTracker` rather than from the inter-burst gap here.
         {
             let vehicle = self.vehicles.get_mut(&vehicle_id).unwrap();
             Self::record_receiver_sighting(vehicle, &self.receiver_id, now);
@@ -1180,28 +1261,6 @@ impl Resolver {
                 &now.to_rfc3339(),
                 false,
             );
-        }
-
-        // Record interval sample for jitter analytics.
-        if let Some(prev_ts) = prev_last_seen {
-            if let Some(interval) = jitter::extract_interval(prev_ts, now) {
-                if let Some(fp_id) = self.vehicle_to_fingerprint.get(&vehicle_id) {
-                    if let Err(e) = self.db.insert_interval_sample(
-                        fp_id,
-                        vehicle_id,
-                        &now.to_rfc3339(),
-                        interval,
-                        None,
-                    ) {
-                        eprintln!("warn: interval sample insert failed: {e}");
-                    } else if let Err(e) = self
-                        .db
-                        .enforce_interval_ring_buffer(fp_id, jitter::MAX_INTERVAL_SAMPLES)
-                    {
-                        eprintln!("warn: ring buffer enforce failed: {e}");
-                    }
-                }
-            }
         }
 
         // Incrementally update presence slot if car_id is assigned.
@@ -2714,6 +2773,121 @@ mod tests {
             "interval_samples must be populated for EezTire fingerprint_correlator \
              matches (path=fingerprint_correlator, valid=false), but count={count} \
              for fingerprint_id={fp_id}"
+        );
+    }
+
+    #[test]
+    fn raw_interval_pipeline_yields_per_transmission_samples() {
+        // Issue #42: a sensor that transmits every 22 s should produce one
+        // interval_samples row per inter-packet gap, not one per correlator
+        // match.  100 packets at 22 s spacing must produce 99 samples whose
+        // mean is ≈ 22 000 ms with sub-100 ms sigma (the input is exactly
+        // periodic, so the only spread comes from rounding at the ms level).
+        use crate::jitter::compute_jitter_profile;
+
+        let mut resolver = in_memory_resolver();
+
+        // 100 packets at exactly 22 s spacing, same near-sentinel sensor_id
+        // (matches the production EezTire scenario from issue #42).  Routes
+        // through process_fingerprint, which creates a fingerprint on the
+        // first packet — every subsequent packet reuses it.
+        let base = chrono::NaiveDateTime::parse_from_str(
+            "2026-04-26 12:00:00.000",
+            "%Y-%m-%d %H:%M:%S%.3f",
+        )
+        .unwrap();
+        for i in 0..100 {
+            let ts = base + chrono::Duration::milliseconds(i * 22_000);
+            let timestamp = ts.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+            let p = make_packet_at(&timestamp, "0xF7FFFFFF", "EezTire", 241, 352.3);
+            resolver.process(&p).unwrap();
+        }
+
+        let veh = resolver
+            .vehicles
+            .values()
+            .find(|v| v.protocol == "EezTire")
+            .expect("EezTire vehicle must exist");
+        let fp_id = veh
+            .fingerprint_id
+            .clone()
+            .expect("vehicle must have a fingerprint_id");
+
+        let count = resolver.db.interval_sample_count(&fp_id).unwrap();
+        assert_eq!(
+            count, 99,
+            "100 packets at 22 s spacing must produce 99 interval samples"
+        );
+
+        let samples = resolver
+            .db
+            .get_interval_samples(&fp_id, jitter::MAX_INTERVAL_SAMPLES)
+            .unwrap();
+        // Every sample is exactly 22_000 ms (timestamps are millisecond-
+        // accurate and evenly spaced), so the profile must be tightly
+        // clustered around the mean with σ well under 100 ms.
+        let profile =
+            compute_jitter_profile(&samples).expect("profile should compute from 99 samples");
+        assert!(
+            profile.sigma_ms < 100.0,
+            "sigma_ms = {} must be < 100 ms for an evenly-spaced stream",
+            profile.sigma_ms
+        );
+    }
+
+    #[test]
+    fn raw_interval_buffer_flushes_after_first_resolution() {
+        // Each subsequent packet from the same sensor must produce exactly
+        // one interval_samples row — the buffer is flushed in the same
+        // `process()` call that pushed the interval.
+        let mut resolver = in_memory_resolver();
+
+        let p1 = make_packet_at("2026-04-26 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
+        let p2 = make_packet_at("2026-04-26 12:00:22.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
+        let p3 = make_packet_at("2026-04-26 12:00:44.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
+
+        resolver.process(&p1).unwrap();
+        let veh = resolver
+            .vehicles
+            .values()
+            .find(|v| v.protocol == "EezTire")
+            .expect("EezTire vehicle must exist");
+        let fp_id = veh.fingerprint_id.clone().unwrap();
+
+        // After packet 1: no interval recorded (first observation only sets
+        // the tracker baseline).
+        assert_eq!(resolver.db.interval_sample_count(&fp_id).unwrap(), 0);
+
+        resolver.process(&p2).unwrap();
+        // After packet 2: one interval (22_000 ms) flushed under fp_id.
+        assert_eq!(resolver.db.interval_sample_count(&fp_id).unwrap(), 1);
+
+        resolver.process(&p3).unwrap();
+        assert_eq!(resolver.db.interval_sample_count(&fp_id).unwrap(), 2);
+    }
+
+    #[test]
+    fn raw_interval_burst_duplicate_rejected() {
+        // Two packets 200 ms apart from the same sensor — well below
+        // RAW_INTERVAL_MIN_MS — must not create an interval sample.
+        let mut resolver = in_memory_resolver();
+
+        let p1 = make_packet_at("2026-04-26 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
+        let p2 = make_packet_at("2026-04-26 12:00:00.200", "0xF7FFFFFF", "EezTire", 241, 352.3);
+
+        resolver.process(&p1).unwrap();
+        resolver.process(&p2).unwrap();
+
+        let veh = resolver
+            .vehicles
+            .values()
+            .find(|v| v.protocol == "EezTire")
+            .expect("EezTire vehicle must exist");
+        let fp_id = veh.fingerprint_id.clone().unwrap();
+        assert_eq!(
+            resolver.db.interval_sample_count(&fp_id).unwrap(),
+            0,
+            "burst-duplicate gaps must not produce interval samples"
         );
     }
 


### PR DESCRIPTION
The previous jitter pipeline collected interval samples between
consecutive successful correlator matches.  For rolling- and bit-flip-ID
protocols the correlator only matches a fraction of received packets, so
the inter-match gap reflected pool size, pressure collisions and rolling
ID frequency rather than the crystal oscillator.  Measured sigma on a
parked van's EezTire was ~41 s — three orders of magnitude above the
true ±20 ppm crystal jitter.

Add a `RawIntervalTracker` keyed on `(sensor_id, rtl433_id)` that records
the gap between consecutive packets *before* fingerprint resolution, and
a deferred-association `RawIntervalBuffer` that holds those intervals
until the correlator assigns a fingerprint.  Wire both into `Resolver`:

  - `observe()` runs at the top of `process()` for every packet
  - the buffer is flushed under the resolved `fingerprint_id` once the
    correlator succeeds (in the same `process()` call)
  - stale tracker entries and unresolved buffer entries are evicted on
    a throttled (≤ once/min) timer driven by the packet stream

Remove the post-correlator interval recording from `process_fingerprint`
and `resolve_burst` — those measured the wrong quantity.

Adds 14 unit tests for the tracker/buffer plus 3 resolver integration
tests, including a 100-packet 22 s scenario that produces 99 samples
with sigma < 100 ms.