### PR TITLE
feat(jitter): Hamming-distance interval tracking for rolling-ID protocols (#43)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ logs/
 *.log
 *.log.*
 start.sh
+__pycache__/

--- a/crates/tracker/src/raw_interval.rs
+++ b/crates/tracker/src/raw_interval.rs
@@ -37,6 +37,38 @@ pub const RAW_INTERVAL_MAX_MS: i64 = 300_000;
 /// drive-bys that never resolved to a fingerprint.
 pub const RAW_INTERVAL_BUFFER_TTL_SECS: i64 = 600;
 
+/// Maximum Hamming distance between two consecutive sensor IDs to be
+/// attributed to the same physical sensor by [`RollingIntervalTracker`].
+///
+/// EezTire / TRW-OOK / TRW-FSK flip 1–3 bits of the sensor ID per
+/// transmission.  Two random 32-bit IDs differ in ~16 bits on average, so a
+/// threshold of 3 cleanly separates same-sensor consecutive packets from
+/// different-sensor packets.
+pub const MAX_HAMMING_DISTANCE: u32 = 3;
+
+/// Maximum pressure delta (kPa) between two consecutive packets attributed
+/// to the same physical sensor in [`RollingIntervalTracker::observe_with_pressure`].
+///
+/// A real tyre's pressure changes by less than 0.1 kPa over a 22 s interval,
+/// so any delta above this threshold indicates two distinct sensors that
+/// happen to be within `MAX_HAMMING_DISTANCE` of each other.
+pub const MAX_PRESSURE_DELTA_KPA: f32 = 5.0;
+
+/// `rtl433_id`s of protocols whose sensor ID rotates on every transmission
+/// via a bit-flip rolling scheme.  Jitter measurement for these protocols
+/// requires Hamming-distance grouping rather than exact sensor-ID equality.
+pub const ROLLING_ID_PROTOCOLS: &[u16] = &[
+    241, // EezTire / Carchet / TST-507
+    298, // TRW-OOK
+    299, // TRW-FSK
+];
+
+/// Whether the given protocol uses a bit-flip rolling sensor ID and so must
+/// be tracked by [`RollingIntervalTracker`] rather than [`RawIntervalTracker`].
+pub fn is_rolling_id_protocol(rtl433_id: u16) -> bool {
+    ROLLING_ID_PROTOCOLS.contains(&rtl433_id)
+}
+
 // ---------------------------------------------------------------------------
 // RawIntervalTracker
 // ---------------------------------------------------------------------------
@@ -64,12 +96,7 @@ impl RawIntervalTracker {
     ///
     /// Returns `None` for the first observation of a sensor, for burst
     /// duplicates, and for cross-session gaps.
-    pub fn observe(
-        &mut self,
-        sensor_id: u32,
-        rtl433_id: u16,
-        now: DateTime<Utc>,
-    ) -> Option<i64> {
+    pub fn observe(&mut self, sensor_id: u32, rtl433_id: u16, now: DateTime<Utc>) -> Option<i64> {
         let key = (sensor_id, rtl433_id);
         let prev = self.last_seen.insert(key, now);
         prev.and_then(|t| {
@@ -90,6 +117,119 @@ impl RawIntervalTracker {
     }
 
     /// Number of tracked sensor keys.  Exposed for tests and diagnostics.
+    pub fn len(&self) -> usize {
+        self.last_seen.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.last_seen.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RollingIntervalTracker
+// ---------------------------------------------------------------------------
+
+/// Tracks raw TX intervals for protocols whose sensor ID rotates on every
+/// transmission (EezTire, TRW-OOK, TRW-FSK).
+///
+/// Unlike [`RawIntervalTracker`], which keys on `(sensor_id, rtl433_id)`,
+/// this tracker keys on `rtl433_id` only and uses Hamming distance between
+/// consecutive sensor IDs to decide whether two packets came from the same
+/// physical sensor.  Two consecutive packets are attributed to the same
+/// sensor when `hamming_distance(prev_id, new_id) <= MAX_HAMMING_DISTANCE`.
+///
+/// In dense environments where two sensors of the same protocol may be in
+/// range simultaneously, [`Self::observe_with_pressure`] adds pressure
+/// continuity as a second matching criterion.
+#[derive(Debug, Default)]
+pub struct RollingIntervalTracker {
+    /// `rtl433_id → (last_sensor_id, last_pressure_kpa, last_timestamp)`.
+    /// `last_pressure_kpa` is `None` when the previous observation was
+    /// recorded via [`Self::observe`] without a pressure value.
+    last_seen: HashMap<u16, (u32, Option<f32>, DateTime<Utc>)>,
+}
+
+impl RollingIntervalTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a packet observation and return the interval (ms) since the
+    /// previous packet of the same protocol if:
+    ///   * Hamming distance between the previous and new sensor IDs is
+    ///     `<= MAX_HAMMING_DISTANCE`, **and**
+    ///   * the gap is inside `[RAW_INTERVAL_MIN_MS, RAW_INTERVAL_MAX_MS]`.
+    ///
+    /// The stored `(sensor_id, timestamp)` for this protocol is always
+    /// updated, regardless of whether an interval is returned.
+    pub fn observe(&mut self, sensor_id: u32, rtl433_id: u16, now: DateTime<Utc>) -> Option<i64> {
+        let prev = self.last_seen.insert(rtl433_id, (sensor_id, None, now));
+        prev.and_then(|(last_id, _, last_ts)| {
+            Self::interval_if_same_sensor(sensor_id, last_id, now, last_ts)
+        })
+    }
+
+    /// Like [`Self::observe`] but additionally requires the pressure delta
+    /// between the two packets to stay within `MAX_PRESSURE_DELTA_KPA`.
+    /// This disambiguates two sensors of the same protocol that happen to
+    /// transmit IDs within Hamming distance 3 of each other.
+    ///
+    /// If the previous observation was recorded via [`Self::observe`]
+    /// (no pressure available), pressure is not used to gate the match —
+    /// the current call falls back to the pure Hamming-distance check.
+    pub fn observe_with_pressure(
+        &mut self,
+        sensor_id: u32,
+        rtl433_id: u16,
+        pressure_kpa: f32,
+        now: DateTime<Utc>,
+    ) -> Option<i64> {
+        let prev = self
+            .last_seen
+            .insert(rtl433_id, (sensor_id, Some(pressure_kpa), now));
+        prev.and_then(|(last_id, last_pressure, last_ts)| {
+            let interval = Self::interval_if_same_sensor(sensor_id, last_id, now, last_ts)?;
+            // If we have a previous pressure to compare against, gate on it.
+            // Otherwise accept the Hamming-only match.
+            if let Some(prev_p) = last_pressure
+                && (pressure_kpa - prev_p).abs() > MAX_PRESSURE_DELTA_KPA
+            {
+                return None;
+            }
+            Some(interval)
+        })
+    }
+
+    /// Combined Hamming + interval gate.  Pulled out so [`Self::observe`]
+    /// and [`Self::observe_with_pressure`] share the same logic.
+    fn interval_if_same_sensor(
+        new_id: u32,
+        last_id: u32,
+        now: DateTime<Utc>,
+        last_ts: DateTime<Utc>,
+    ) -> Option<i64> {
+        let hamming = (new_id ^ last_id).count_ones();
+        if hamming > MAX_HAMMING_DISTANCE {
+            return None;
+        }
+        let gap = (now - last_ts).num_milliseconds();
+        if (RAW_INTERVAL_MIN_MS..=RAW_INTERVAL_MAX_MS).contains(&gap) {
+            Some(gap)
+        } else {
+            None
+        }
+    }
+
+    /// Drop entries whose last-seen timestamp is older than `max_age_secs`.
+    /// Call periodically to release memory for protocols whose sensors have
+    /// departed.
+    pub fn evict_stale(&mut self, now: DateTime<Utc>, max_age_secs: i64) {
+        self.last_seen
+            .retain(|_, (_, _, ts)| (now - *ts).num_seconds() < max_age_secs);
+    }
+
+    /// Number of tracked protocol keys.  Exposed for tests and diagnostics.
     pub fn len(&self) -> usize {
         self.last_seen.len()
     }
@@ -124,13 +264,7 @@ impl RawIntervalBuffer {
     }
 
     /// Append an interval observation for the given sensor.
-    pub fn push(
-        &mut self,
-        sensor_id: u32,
-        rtl433_id: u16,
-        interval_ms: i64,
-        ts: DateTime<Utc>,
-    ) {
+    pub fn push(&mut self, sensor_id: u32, rtl433_id: u16, interval_ms: i64, ts: DateTime<Utc>) {
         self.inner
             .entry((sensor_id, rtl433_id))
             .or_default()
@@ -350,5 +484,191 @@ mod tests {
         // Force every interval out by evicting with a very large now.
         buf.evict_stale(t0() + Duration::seconds(10_000), 600);
         assert!(buf.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // RollingIntervalTracker
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rolling_first_observation_returns_none() {
+        let mut tracker = RollingIntervalTracker::new();
+        assert_eq!(tracker.observe(0xFFFFFFFF, 241, t0()), None);
+    }
+
+    #[test]
+    fn rolling_same_sensor_within_hamming_threshold_returns_interval() {
+        // 0xFFFFFFFF → 0xFBFFFFDF: 2 bits flipped (within threshold).
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        let gap = tracker.observe(0xFBFFFFDF, 241, t0() + Duration::milliseconds(22_000));
+        assert_eq!(gap, Some(22_000));
+    }
+
+    #[test]
+    fn rolling_three_bit_flip_accepted() {
+        // 0xFFFFFFFF → 0xFDFFFDFB: 3 bits flipped — at the threshold.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        let gap = tracker.observe(0xFDFFFDFB, 241, t0() + Duration::milliseconds(22_000));
+        assert_eq!(
+            gap,
+            Some(22_000),
+            "Hamming distance == threshold must match"
+        );
+    }
+
+    #[test]
+    fn rolling_above_hamming_threshold_returns_none() {
+        // 0xFFFFFFFF → 0xFFFF0FFF: 4 bits differ — different sensor.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        let gap = tracker.observe(0xFFFF0FFF, 241, t0() + Duration::milliseconds(22_000));
+        assert_eq!(
+            gap, None,
+            "consecutive packets > MAX_HAMMING_DISTANCE bits apart must not produce an interval"
+        );
+    }
+
+    #[test]
+    fn rolling_burst_duplicate_below_min_rejected() {
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        // 200 ms gap, 1 bit flipped — gap below RAW_INTERVAL_MIN_MS.
+        let gap = tracker.observe(0xFBFFFFFF, 241, t0() + Duration::milliseconds(200));
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn rolling_cross_session_gap_above_max_rejected() {
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        // 10 minutes — well above RAW_INTERVAL_MAX_MS, even though the IDs
+        // are within Hamming threshold.
+        let gap = tracker.observe(0xFBFFFFFF, 241, t0() + Duration::minutes(10));
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn rolling_state_advances_even_on_rejected_match() {
+        // After a rejected match (different sensor), the stored state must
+        // still advance to the rejecting packet so the *next* packet is
+        // measured against the most recent observation.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        // 0xFFFF0FFF: 4 bits flipped from 0xFFFFFFFF → rejected.
+        let _ = tracker.observe(0xFFFF0FFF, 241, t0() + Duration::milliseconds(22_000));
+        // 0xFFFF0FFF → 0xFFFE0FFF: 1 bit flipped from the rejected packet → match.
+        let gap = tracker.observe(0xFFFE0FFF, 241, t0() + Duration::milliseconds(44_000));
+        assert_eq!(gap, Some(22_000));
+    }
+
+    #[test]
+    fn rolling_protocols_kept_separate() {
+        // Two protocols sharing a sensor_id must not produce an interval —
+        // the tracker is keyed per-protocol.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        let gap = tracker.observe(0xFFFFFFFF, 298, t0() + Duration::milliseconds(22_000));
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn rolling_observe_with_pressure_accepts_close_pressure() {
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe_with_pressure(0xFFFFFFFF, 241, 250.0, t0());
+        let gap = tracker.observe_with_pressure(
+            0xFBFFFFDF,
+            241,
+            250.5,
+            t0() + Duration::milliseconds(22_000),
+        );
+        assert_eq!(gap, Some(22_000));
+    }
+
+    #[test]
+    fn rolling_observe_with_pressure_rejects_large_pressure_delta() {
+        // Two sensors at very different pressures whose IDs happen to be
+        // within Hamming distance 3 — the pressure delta must reject the
+        // match.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe_with_pressure(0xFFFFFFFF, 241, 250.0, t0());
+        let gap = tracker.observe_with_pressure(
+            0xFBFFFFDF,
+            241,
+            300.0, // Δ = 50 kPa, well above MAX_PRESSURE_DELTA_KPA
+            t0() + Duration::milliseconds(22_000),
+        );
+        assert_eq!(
+            gap, None,
+            "pressure delta > MAX_PRESSURE_DELTA_KPA must reject the match"
+        );
+    }
+
+    #[test]
+    fn rolling_observe_with_pressure_pressure_does_not_rescue_far_hamming() {
+        // Even if the pressures match exactly, a Hamming distance > threshold
+        // still rejects the interval.  0xFFFF0FFF differs from 0xFFFFFFFF
+        // by 4 bits — above MAX_HAMMING_DISTANCE.
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe_with_pressure(0xFFFFFFFF, 241, 250.0, t0());
+        let gap = tracker.observe_with_pressure(
+            0xFFFF0FFF,
+            241,
+            250.0,
+            t0() + Duration::milliseconds(22_000),
+        );
+        assert_eq!(gap, None);
+    }
+
+    #[test]
+    fn rolling_evict_stale_removes_old_protocol_entries() {
+        let mut tracker = RollingIntervalTracker::new();
+        tracker.observe(0xFFFFFFFF, 241, t0());
+        tracker.observe(0xFFFFFFFF, 298, t0() + Duration::seconds(150));
+        tracker.evict_stale(t0() + Duration::seconds(200), 60);
+        assert_eq!(
+            tracker.len(),
+            1,
+            "only the recent protocol entry should survive eviction"
+        );
+    }
+
+    #[test]
+    fn is_rolling_id_protocol_recognises_known_protocols() {
+        assert!(is_rolling_id_protocol(241));
+        assert!(is_rolling_id_protocol(298));
+        assert!(is_rolling_id_protocol(299));
+        assert!(!is_rolling_id_protocol(89));
+        assert!(!is_rolling_id_protocol(208));
+    }
+
+    #[test]
+    fn rolling_synthetic_eeztire_stream_yields_per_transmission_intervals() {
+        // Issue #43 acceptance: 100 synthetic EezTire packets at 22 s
+        // intervals, each with 1–2 random bit flips relative to the previous,
+        // must produce 99 interval samples whose mean is ~22_000 ms.
+        let mut tracker = RollingIntervalTracker::new();
+        let mut id: u32 = 0xFFFFFFFF;
+        let mut intervals = Vec::new();
+        // Pseudo-random bit-flip pattern (deterministic for reproducibility).
+        let bit_seq = [3u32, 17, 28, 9, 14, 22, 5, 30, 1, 11, 26, 19];
+        for i in 0..100 {
+            let ts = t0() + Duration::milliseconds((i as i64) * 22_000);
+            if let Some(g) = tracker.observe(id, 241, ts) {
+                intervals.push(g);
+            }
+            // Flip 1–2 bits for the next packet.
+            let bit = bit_seq[i % bit_seq.len()];
+            id ^= 1 << bit;
+            if i % 3 == 0 {
+                id ^= 1 << bit_seq[(i + 1) % bit_seq.len()];
+            }
+        }
+        assert_eq!(intervals.len(), 99);
+        // All gaps were exactly 22_000 ms by construction.
+        for g in &intervals {
+            assert_eq!(*g, 22_000);
+        }
     }
 }

--- a/crates/tracker/src/resolver.rs
+++ b/crates/tracker/src/resolver.rs
@@ -15,6 +15,7 @@ use crate::jaccard::{
 use crate::jitter;
 use crate::raw_interval::{
     RAW_INTERVAL_BUFFER_TTL_SECS, RAW_INTERVAL_MAX_MS, RawIntervalBuffer, RawIntervalTracker,
+    RollingIntervalTracker, is_rolling_id_protocol,
 };
 use crate::{
     CROSS_RECEIVER_WINDOW_MS, FINGERPRINT_MAX_GAP_DAYS, MAX_PLAUSIBLE_PRESSURE_KPA,
@@ -154,6 +155,10 @@ pub struct Resolver {
     /// These intervals reflect the true TX cadence (and hence oscillator
     /// jitter) rather than the inter-correlator-match latency.
     raw_interval_tracker: RawIntervalTracker,
+    /// Hamming-distance-keyed interval tracker for protocols whose sensor ID
+    /// rotates on every transmission (EezTire, TRW-OOK, TRW-FSK).  See
+    /// `crate::raw_interval::RollingIntervalTracker`.
+    rolling_interval_tracker: RollingIntervalTracker,
     /// Buffers raw intervals per sensor key until the correlator resolves a
     /// fingerprint for the sensor.  Drained into `interval_samples` after
     /// resolution; stale entries are dropped after `RAW_INTERVAL_BUFFER_TTL_SECS`.
@@ -184,6 +189,7 @@ impl Resolver {
             vehicle_to_fingerprint: HashMap::new(),
             merged_car_ids: HashSet::new(),
             raw_interval_tracker: RawIntervalTracker::new(),
+            rolling_interval_tracker: RollingIntervalTracker::new(),
             raw_interval_buffer: RawIntervalBuffer::new(),
             last_raw_interval_evict: None,
         };
@@ -252,10 +258,25 @@ impl Resolver {
         // measures inter-match latency rather than the sensor's true TX
         // cadence.  Successful observations are buffered per-sensor and
         // flushed to interval_samples after fingerprint resolution.
-        if let Some(interval_ms) =
+        //
+        // Rolling-ID protocols (EezTire, TRW-OOK, TRW-FSK) flip 1–3 bits of
+        // the sensor ID on every transmission, so the per-`sensor_id` tracker
+        // never sees a repeat.  Route them through the Hamming-distance
+        // tracker that groups consecutive packets of the same protocol when
+        // the IDs are close enough to plausibly originate from the same
+        // physical sensor.
+        let raw_interval = if is_rolling_id_protocol(packet.rtl433_id) {
+            self.rolling_interval_tracker.observe_with_pressure(
+                sensor_id,
+                packet.rtl433_id,
+                packet.pressure_kpa,
+                ts,
+            )
+        } else {
             self.raw_interval_tracker
                 .observe(sensor_id, packet.rtl433_id, ts)
-        {
+        };
+        if let Some(interval_ms) = raw_interval {
             self.raw_interval_buffer
                 .push(sensor_id, packet.rtl433_id, interval_ms, ts);
         }
@@ -306,12 +327,7 @@ impl Resolver {
         if let Ok(Some(vehicle_id)) = result.as_ref()
             && let Some(fp_id) = self.vehicle_to_fingerprint.get(vehicle_id).cloned()
         {
-            self.flush_raw_intervals_for_sensor(
-                sensor_id,
-                packet.rtl433_id,
-                *vehicle_id,
-                &fp_id,
-            );
+            self.flush_raw_intervals_for_sensor(sensor_id, packet.rtl433_id, *vehicle_id, &fp_id);
         }
 
         // Throttled eviction of stale tracker entries and unresolved buffer
@@ -368,6 +384,8 @@ impl Resolver {
         }
         self.last_raw_interval_evict = Some(now);
         self.raw_interval_tracker
+            .evict_stale(now, RAW_INTERVAL_MAX_MS / 1000);
+        self.rolling_interval_tracker
             .evict_stale(now, RAW_INTERVAL_MAX_MS / 1000);
         self.raw_interval_buffer
             .evict_stale(now, RAW_INTERVAL_BUFFER_TTL_SECS);
@@ -2842,9 +2860,27 @@ mod tests {
         // `process()` call that pushed the interval.
         let mut resolver = in_memory_resolver();
 
-        let p1 = make_packet_at("2026-04-26 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
-        let p2 = make_packet_at("2026-04-26 12:00:22.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
-        let p3 = make_packet_at("2026-04-26 12:00:44.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
+        let p1 = make_packet_at(
+            "2026-04-26 12:00:00.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            352.3,
+        );
+        let p2 = make_packet_at(
+            "2026-04-26 12:00:22.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            352.3,
+        );
+        let p3 = make_packet_at(
+            "2026-04-26 12:00:44.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            352.3,
+        );
 
         resolver.process(&p1).unwrap();
         let veh = resolver
@@ -2872,8 +2908,20 @@ mod tests {
         // RAW_INTERVAL_MIN_MS — must not create an interval sample.
         let mut resolver = in_memory_resolver();
 
-        let p1 = make_packet_at("2026-04-26 12:00:00.000", "0xF7FFFFFF", "EezTire", 241, 352.3);
-        let p2 = make_packet_at("2026-04-26 12:00:00.200", "0xF7FFFFFF", "EezTire", 241, 352.3);
+        let p1 = make_packet_at(
+            "2026-04-26 12:00:00.000",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            352.3,
+        );
+        let p2 = make_packet_at(
+            "2026-04-26 12:00:00.200",
+            "0xF7FFFFFF",
+            "EezTire",
+            241,
+            352.3,
+        );
 
         resolver.process(&p1).unwrap();
         resolver.process(&p2).unwrap();
@@ -2889,6 +2937,136 @@ mod tests {
             0,
             "burst-duplicate gaps must not produce interval samples"
         );
+    }
+
+    #[test]
+    fn rolling_id_eeztire_stream_with_bit_flips_records_intervals() {
+        // Issue #43: a parked EezTire transmits every 22 s with a different
+        // sensor_id on each packet (1–3 bit flips per transmission).  Before
+        // the fix the per-`sensor_id` tracker never saw a repeat and recorded
+        // zero intervals.  The Hamming-distance-keyed `RollingIntervalTracker`
+        // groups consecutive packets and produces one interval per gap.
+        let mut resolver = in_memory_resolver();
+
+        // 12 packets, 22 s apart, each differing from the previous by 1–2
+        // random bits.  Start from 0xF7FFFFFF and walk through bit flips.
+        let mut id: u32 = 0xF7FFFFFF;
+        let bit_seq = [3u32, 17, 28, 9, 14, 22, 5, 30, 1, 11, 26];
+        let base = chrono::NaiveDateTime::parse_from_str(
+            "2026-04-26 12:00:00.000",
+            "%Y-%m-%d %H:%M:%S%.3f",
+        )
+        .unwrap();
+        for i in 0..12 {
+            let ts = base + chrono::Duration::milliseconds((i as i64) * 22_000);
+            let timestamp = ts.format("%Y-%m-%d %H:%M:%S%.3f").to_string();
+            let id_str = format!("0x{:08X}", id);
+            let p = make_packet_at(&timestamp, &id_str, "EezTire", 241, 352.3);
+            resolver.process(&p).unwrap();
+            // Flip one bit for the next packet; first observation has no bit
+            // flip applied yet because we read `id` *before* the mutation.
+            id ^= 1u32 << bit_seq[i % bit_seq.len()];
+        }
+
+        let veh = resolver
+            .vehicles
+            .values()
+            .find(|v| v.protocol == "EezTire")
+            .expect("EezTire vehicle must exist");
+        let fp_id = veh
+            .fingerprint_id
+            .clone()
+            .expect("vehicle must have a fingerprint_id");
+        let count = resolver.db.interval_sample_count(&fp_id).unwrap();
+        // 12 packets → at most 11 intervals.  The Hamming-distance tracker
+        // should accept all of them since each transition is exactly 1 bit.
+        assert_eq!(
+            count, 11,
+            "12 EezTire packets at 22 s spacing with 1-bit flips must produce \
+             11 interval samples via Hamming-distance grouping (got {count})"
+        );
+    }
+
+    #[test]
+    fn rolling_id_two_simultaneous_sensors_separated_by_pressure() {
+        // Two EezTire sensors transmit in alternation at very different
+        // pressures (250 vs 350 kPa).  Their bit-flipping IDs may happen to
+        // fall within Hamming distance 3 of each other, but the pressure
+        // delta gate (`MAX_PRESSURE_DELTA_KPA`) must reject any cross-sensor
+        // attribution so that no spurious intervals are recorded.
+        let mut resolver = in_memory_resolver();
+
+        let base = chrono::NaiveDateTime::parse_from_str(
+            "2026-04-26 12:00:00.000",
+            "%Y-%m-%d %H:%M:%S%.3f",
+        )
+        .unwrap();
+
+        // Sensor A: 250 kPa, IDs walk 0xFFFFFFFF, 0xFBFFFFFF, 0xFBFFFFEF, ...
+        // Sensor B: 350 kPa, IDs walk 0xFFFFFFEF, 0xFFFFFFFF, 0xFBFFFFFF, ...
+        // Note that some of B's IDs land within Hamming-3 of A's previous ID.
+        let sensor_a_ids = [0xFFFFFFFFu32, 0xFBFFFFFF, 0xFBFFFFEF];
+        let sensor_b_ids = [0xFFFFFFEFu32, 0xFFFFFFFF, 0xFBFFFFFF];
+
+        // Interleave the two streams: A at t=0,22,44; B at t=11,33,55.
+        for i in 0..3 {
+            let ts_a = base + chrono::Duration::milliseconds((i as i64) * 22_000);
+            let ts_b = base + chrono::Duration::milliseconds((i as i64) * 22_000 + 11_000);
+            let p_a = make_packet_at(
+                &ts_a.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+                &format!("0x{:08X}", sensor_a_ids[i]),
+                "EezTire",
+                241,
+                250.0,
+            );
+            let p_b = make_packet_at(
+                &ts_b.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+                &format!("0x{:08X}", sensor_b_ids[i]),
+                "EezTire",
+                241,
+                350.0,
+            );
+            resolver.process(&p_a).unwrap();
+            resolver.process(&p_b).unwrap();
+        }
+
+        // Two distinct EezTire fingerprints must exist (one per pressure).
+        let eez_vehicles: Vec<_> = resolver
+            .vehicles
+            .values()
+            .filter(|v| v.protocol == "EezTire")
+            .collect();
+        assert_eq!(
+            eez_vehicles.len(),
+            2,
+            "two distinct pressure signatures must produce two EezTire vehicles"
+        );
+
+        // The interval tracker is keyed only on rtl433_id, so any cross-sensor
+        // attribution would have produced ~11 s intervals (alternating A→B).
+        // The pressure gate must suppress them: the only intervals recorded
+        // come from genuine same-sensor transitions (~22 s).  In an
+        // interleaved stream every `observe_with_pressure` call sees a large
+        // pressure delta from the prior packet, so *zero* intervals should be
+        // recorded under either fingerprint.
+        for veh in eez_vehicles {
+            if let Some(fp) = veh.fingerprint_id.as_ref() {
+                let samples = resolver
+                    .db
+                    .get_interval_samples(fp, jitter::MAX_INTERVAL_SAMPLES)
+                    .unwrap();
+                for s in &samples {
+                    // No genuine 22 s gap exists between same-sensor packets
+                    // in this interleaved stream (the two sensors alternate),
+                    // so any sample at all would be a cross-attribution.
+                    assert!(
+                        *s < 5_000 || *s > 18_000,
+                        "spurious cross-sensor interval recorded: {} ms",
+                        s
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -241,6 +241,20 @@ CREATE INDEX IF NOT EXISTS idx_interval_ts
     ON interval_samples(ts);
 """
 
+MIGRATION_V11_DESCRIPTION = (
+    "clear interval_samples and jitter columns: methodology fix (issue #43)"
+)
+MIGRATION_V11 = """
+DELETE FROM interval_samples;
+UPDATE fingerprints SET
+    jitter_sigma_ms   = NULL,
+    jitter_skewness   = NULL,
+    jitter_kurtosis   = NULL,
+    jitter_acf_lag1   = NULL,
+    jitter_samples    = NULL,
+    jitter_updated_at = NULL;
+"""
+
 MIGRATIONS = [
     (1, MIGRATION_V1_DESCRIPTION, None),
     (2, MIGRATION_V2_DESCRIPTION, MIGRATION_V2),
@@ -252,6 +266,7 @@ MIGRATIONS = [
     (8, MIGRATION_V8_DESCRIPTION, MIGRATION_V8),
     (9, MIGRATION_V9_DESCRIPTION, MIGRATION_V9),
     (10, MIGRATION_V10_DESCRIPTION, MIGRATION_V10),
+    (11, MIGRATION_V11_DESCRIPTION, MIGRATION_V11),
 ]
  
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
EezTire / TRW-OOK / TRW-FSK rotate their sensor ID on every transmission
(1–3 bit flips per packet), so the (sensor_id, rtl433_id)-keyed
RawIntervalTracker from #42 never sees a repeat and records zero
intervals for these protocols.

Add RollingIntervalTracker, keyed on rtl433_id only, that groups
consecutive packets when the IDs are within MAX_HAMMING_DISTANCE = 3
bits — the natural separation between same-sensor bit flips and
unrelated 32-bit IDs (~16 bits apart on average).  observe_with_pressure
adds a MAX_PRESSURE_DELTA_KPA = 5.0 kPa gate to disambiguate two
simultaneous sensors of the same protocol whose IDs happen to land
within the Hamming threshold.

The Resolver now dispatches each packet to the appropriate tracker via
is_rolling_id_protocol(rtl433_id) before running the correlator; the
push/drain flow through RawIntervalBuffer is unchanged.

Migration v11 wipes pre-fix interval_samples and the dependent jitter
columns on fingerprints so stale measurements don't contaminate the
post-fix profile.

https://claude.ai/code/session_014jCMoLQ5ciytzMu37GVN5q